### PR TITLE
Fix component revision tracking

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -130,7 +130,9 @@ func (comp *Component) EvalHealth(templateContext map[string]interface{}) (bool,
 // Trait is ComponentTrait
 type Trait struct {
 	// The Name is name of TraitDefinition, actually it's a type of the trait instance
-	Name               string
+	Name string
+	// Type is the original type name specified in the application, it can contain revision information
+	Type               string
 	CapabilityCategory types.CapabilityCategory
 	Params             map[string]interface{}
 

--- a/pkg/appfile/appfile_test.go
+++ b/pkg/appfile/appfile_test.go
@@ -716,6 +716,7 @@ func TestBaseGenerateComponent(t *testing.T) {
 	assert.NoError(t, err)
 	tr := &Trait{
 		Name:   traitName,
+		Type:   traitName,
 		engine: definition.NewTraitAbstractEngine(traitName),
 		Template: `outputs:mytrait:{
 if context.componentType == "stateless" {

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -501,14 +501,10 @@ func (p *Parser) convertTemplate2Component(name, typ string, props *runtime.RawE
 	if err != nil {
 		return nil, errors.WithMessagef(err, "fail to parse settings for %s", name)
 	}
-	cpType, err := util.ConvertDefinitionRevName(typ)
-	if err != nil {
-		cpType = typ
-	}
 	return &Component{
 		Traits:             []*Trait{},
 		Name:               name,
-		Type:               cpType,
+		Type:               typ,
 		CapabilityCategory: templ.CapabilityCategory,
 		FullTemplate:       templ,
 		Params:             settings,
@@ -542,7 +538,7 @@ func setComponentDefinitions(af *Appfile, comps []*Component) {
 		if comp.FullTemplate.ComponentDefinition != nil {
 			cd := comp.FullTemplate.ComponentDefinition.DeepCopy()
 			cd.Status = v1beta1.ComponentDefinitionStatus{}
-			af.RelatedComponentDefinitions[comp.FullTemplate.ComponentDefinition.Name] = cd
+			af.RelatedComponentDefinitions[comp.Type] = cd
 		}
 		for _, t := range comp.Traits {
 			if t == nil {
@@ -551,7 +547,7 @@ func setComponentDefinitions(af *Appfile, comps []*Component) {
 			if t.FullTemplate.TraitDefinition != nil {
 				td := t.FullTemplate.TraitDefinition.DeepCopy()
 				td.Status = v1beta1.TraitDefinitionStatus{}
-				af.RelatedTraitDefinitions[t.FullTemplate.TraitDefinition.Name] = td
+				af.RelatedTraitDefinitions[t.Type] = td
 			}
 		}
 	}
@@ -701,6 +697,7 @@ func (p *Parser) convertTemplate2Trait(name string, properties map[string]interf
 	}
 	return &Trait{
 		Name:               traitName,
+		Type:               name,
 		CapabilityCategory: templ.CapabilityCategory,
 		Params:             properties,
 		Template:           templ.TemplateStr,

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -378,6 +378,7 @@ var _ = Describe("Test application parser", func() {
 					Traits: []*Trait{
 						{
 							Name: "scaler",
+							Type: "scaler",
 							Params: map[string]interface{}{
 								"replicas": float64(1),
 							},

--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -223,28 +223,48 @@ func IsNotFoundInAppRevision(err error) bool {
 }
 
 func verifyRevisionName(capName string, capType types.CapType, apprev *v1beta1.ApplicationRevision) string {
-	if strings.Contains(capName, "@") {
-		splitName := capName[0:strings.LastIndex(capName, "@")]
-		ok := false
-
+	if _, exist := func() bool {
 		switch capType {
 		case types.TypeComponentDefinition:
-			_, ok = apprev.Spec.ComponentDefinitions[splitName]
+			_, ok := apprev.Spec.ComponentDefinitions[capName]
+			return ok
 		case types.TypeTrait:
-			_, ok = apprev.Spec.TraitDefinitions[splitName]
+			_, ok := apprev.Spec.TraitDefinitions[capName]
+			return ok
 		case types.TypePolicy:
-			_, ok = apprev.Spec.PolicyDefinitions[splitName]
+			_, ok := apprev.Spec.PolicyDefinitions[capName]
+			return ok
 		case types.TypeWorkflowStep:
-			_, ok = apprev.Spec.WorkflowStepDefinitions[splitName]
+			_, ok := apprev.Spec.WorkflowStepDefinitions[capName]
+			return ok
 		default:
-			return capName
+			return false
 		}
-
-		if ok {
-			return splitName
-		}
+	}(); exist {
+		return capName
 	}
 
+	if strings.Contains(capName, "@") {
+		splitName := capName[0:strings.LastIndex(capName, "@")]
+		switch capType {
+		case types.TypeComponentDefinition:
+			if _, ok := apprev.Spec.ComponentDefinitions[splitName]; ok {
+				return splitName
+			}
+		case types.TypeTrait:
+			if _, ok := apprev.Spec.TraitDefinitions[splitName]; ok {
+				return splitName
+			}
+		case types.TypePolicy:
+			if _, ok := apprev.Spec.PolicyDefinitions[splitName]; ok {
+				return splitName
+			}
+		case types.TypeWorkflowStep:
+			if _, ok := apprev.Spec.WorkflowStepDefinitions[splitName]; ok {
+				return splitName
+			}
+		}
+	}
 	return capName
 }
 

--- a/pkg/appfile/validate_test.go
+++ b/pkg/appfile/validate_test.go
@@ -41,12 +41,14 @@ var _ = Describe("Test validate CUE schematic Appfile", func() {
 			Traits: []*Trait{
 				{
 					Name:               "myscaler",
+					Type:               "myscaler",
 					CapabilityCategory: types.CUECategory,
 					Template:           tc.traitDefTmpl1,
 					engine:             definition.NewTraitAbstractEngine("myscaler"),
 				},
 				{
 					Name:               "myingress",
+					Type:               "myingress",
 					CapabilityCategory: types.CUECategory,
 					Template:           tc.traitDefTmpl2,
 					engine:             definition.NewTraitAbstractEngine("myingress"),

--- a/pkg/controller/core.oam.dev/v1beta1/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1beta1/application/revision.go
@@ -149,7 +149,8 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 		if w.FullTemplate.ComponentDefinition != nil {
 			cd := w.FullTemplate.ComponentDefinition.DeepCopy()
 			cd.Status = v1beta1.ComponentDefinitionStatus{}
-			appRev.Spec.ComponentDefinitions[w.FullTemplate.ComponentDefinition.Name] = cd.DeepCopy()
+			key := w.Type
+			appRev.Spec.ComponentDefinitions[key] = cd.DeepCopy()
 		}
 		if w.FullTemplate.WorkloadDefinition != nil {
 			wd := w.FullTemplate.WorkloadDefinition.DeepCopy()
@@ -163,7 +164,8 @@ func (h *AppHandler) gatherRevisionSpec(af *appfile.Appfile) (*v1beta1.Applicati
 			if t.FullTemplate.TraitDefinition != nil {
 				td := t.FullTemplate.TraitDefinition.DeepCopy()
 				td.Status = v1beta1.TraitDefinitionStatus{}
-				appRev.Spec.TraitDefinitions[t.FullTemplate.TraitDefinition.Name] = td.DeepCopy()
+				key := t.Type
+				appRev.Spec.TraitDefinitions[key] = td.DeepCopy()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- store components' original type names to match revision lookup

## Testing
- `go test ./pkg/appfile/... -run TestParse -run TestConvert -count=1` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68763c802220832fb81b87d6ef602673
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed component and trait revision tracking by storing their original type names, ensuring correct lookup and matching in application revisions.

- **Bug Fixes**
  - Updated logic to use the original type name for component and trait definitions.
  - Improved revision name verification to handle names with and without revision suffixes.

<!-- End of auto-generated description by cubic. -->

